### PR TITLE
Implement "run-with-summary" in CI 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,10 +118,3 @@ jobs:
           SITES_PATH=$GIT_PATH bin/task exec-platform -- ddev start || \
             (echo "ddev start failed. Logs:"
             )
-
-      - name: Show Docker Logs
-        if: always()
-        env:
-          SITES_PATH: /var/platform/Sites/dashboard/live
-        run: |
-          run-with-summary bin/task exec-platform -- docker compose logs


### PR DESCRIPTION
Adds jon's "goatscripts" for `run-with-summary`.

### Overview
This pull request:

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Has tests?    | no
| BC breaks?    | no     
| Deprecations? | no 

### Summary
The [goatscripts](https://github.com/jonpugh/goatscripts) are universally useful command-line bash scripts that make development easier.

This adds the `run-with-summary` script, that lets you see commands running in real-time and saves output to the GitHub job summary.

See https://github.com/operations-project/ansible-collection-site-runner/actions/runs/18821642134?pr=10 for an example.